### PR TITLE
Add TLS port to SMTP docs

### DIFF
--- a/getting-started/smtp.mdx
+++ b/getting-started/smtp.mdx
@@ -4,6 +4,6 @@ description: 'Learn how to send emails via SMTP with Plunk'
 ---
 ## Connecting to Plunk via SMTP
 - **Host**: `smtp.useplunk.com`
-- **Port**: `465`
+- **Port**: `465` (or `587` for TLS)
 - **Username**: `plunk`
 - **Password**: Your Secret API Key


### PR DESCRIPTION
The docs does not reflect that the TLS port 587 can be used. It does however show in the account specific SMTP configuration. This PR adds the TLS port to the docs.