### PR TITLE
Specify volume in the docker compose file in self-hosting docs

### DIFF
--- a/getting-started/self-hosting.mdx
+++ b/getting-started/self-hosting.mdx
@@ -133,6 +133,9 @@ services:
   redis:
     image: redis
 
+volumes:
+  postgres_data:
+
 ```
 
 ### 3. Running Plunk


### PR DESCRIPTION
In the latest version of docker-compose, running the docker-compose.yml file for the current document results in the following error:

```
service "db" refers to undefined volume postgres_data: invalid compose project
```

To resolve this error, the definition of the volume is required in the docker-compose file. 

```
volumes:
  postgres_data:
```